### PR TITLE
묵찌빠 프로그램 [STEP 1] 노움, 에피

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,38 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### STEP 1
 <h1 align="center">
-  <img src="https://github.com/rohhyungwoo/ios-rock-scissor-paper/assets/56967908/7197dd4a-8666-4feb-8d4e-2a62555d9507" width=85%>
+  <img src="https://github.com/rohhyungwoo/ios-rock-scissor-paper/assets/56967908/8db30b4a-6bfe-4a04-8fdf-ae9c3db33e11" width=85%>
 </h1>
 
 ### STEP 2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 | <img src="https://avatars.githubusercontent.com/u/56967908?v=4" width=120> | <img src="https://avatars.githubusercontent.com/u/67363759?v=4" width=120> |
 | :---: | :---: |
-| 에피 | 노움 |
+| [에피](https://github.com/hyeffie) | [노움](https://github.com/rohhyungwoo) |
 
 ## 타임라인
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 
 ## 팀원
 
+
 | <img src="https://avatars.githubusercontent.com/u/56967908?v=4" width=120> | <img src="https://avatars.githubusercontent.com/u/67363759?v=4" width=120> |
 | --- | --- |
+<h1 align="center">
 | 에피 | 노움 |
+</h1>
 
 ## 타임라인
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@
 
 
 | <img src="https://avatars.githubusercontent.com/u/56967908?v=4" width=120> | <img src="https://avatars.githubusercontent.com/u/67363759?v=4" width=120> |
-| --- | --- |
-<h1 align="center">
+| :---: | :---: |
 | 에피 | 노움 |
-</h1>
 
 ## 타임라인
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
-# Tasty Code
+# 콘솔 묵찌빠 앱
 
-### 묵찌빠 프로젝트 저장소
+콘솔에서 한 명의 사용자가 컴퓨터와 가위바위보 하는 게임입니다.
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다.
+## 팀원
+
+| <img src="https://avatars.githubusercontent.com/u/56967908?v=4" width=120> | <img src="https://avatars.githubusercontent.com/u/67363759?v=4" width=120> |
+| --- | --- |
+| 노움 | 에피 |
+
+## 타임라인
+
+## 다이어그램 로그
+
+### STEP 1
+<h1 align="center">
+  <img src="https://github.com/rohhyungwoo/ios-rock-scissor-paper/assets/56967908/7197dd4a-8666-4feb-8d4e-2a62555d9507" width=85%>
+</h1>
+
+### STEP 2
+
+## 실행 화면
+
+## 트러블슈팅
+
+## 참고 링크

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | <img src="https://avatars.githubusercontent.com/u/56967908?v=4" width=120> | <img src="https://avatars.githubusercontent.com/u/67363759?v=4" width=120> |
 | --- | --- |
-| 노움 | 에피 |
+| 에피 | 노움 |
 
 ## 타임라인
 

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
 		CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */; };
 		CCD0ECC62B0DF016004FDED3 /* Hand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC52B0DF016004FDED3 /* Hand.swift */; };
+		CCD0ECC82B0E0AEB004FDED3 /* RSPPlayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,6 +30,7 @@
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPApp.swift; sourceTree = "<group>"; };
 		CCD0ECC52B0DF016004FDED3 /* Hand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hand.swift; sourceTree = "<group>"; };
+		CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPPlayable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +66,7 @@
 				CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */,
 				C7ABA0E0254EA63000B2367D /* main.swift */,
 				CCD0ECC52B0DF016004FDED3 /* Hand.swift */,
+				CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -128,6 +131,7 @@
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
 				CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */,
 				CCD0ECC62B0DF016004FDED3 /* Hand.swift in Sources */,
+				CCD0ECC82B0E0AEB004FDED3 /* RSPPlayable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -69,11 +69,11 @@
 		C7ABA0DF254EA63000B2367D /* RockPaperScissors */ = {
 			isa = PBXGroup;
 			children = (
-				CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */,
 				C7ABA0E0254EA63000B2367D /* main.swift */,
-				CCD0ECC52B0DF016004FDED3 /* Hand.swift */,
+				CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */,
 				CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */,
 				CCD0ECC92B0E0E61004FDED3 /* RSPResult.swift */,
+				CCD0ECC52B0DF016004FDED3 /* Hand.swift */,
 				CCD0ECCB2B0E0F0B004FDED3 /* Judge.swift */,
 				CCD0ECCD2B0E1DD8004FDED3 /* Menu.swift */,
 			);

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */; };
 		CCD0ECC62B0DF016004FDED3 /* Hand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC52B0DF016004FDED3 /* Hand.swift */; };
 		CCD0ECC82B0E0AEB004FDED3 /* RSPPlayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */; };
+		CCD0ECCA2B0E0E61004FDED3 /* RSPResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC92B0E0E61004FDED3 /* RSPResult.swift */; };
+		CCD0ECCC2B0E0F0B004FDED3 /* Judge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECCB2B0E0F0B004FDED3 /* Judge.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,6 +33,8 @@
 		CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPApp.swift; sourceTree = "<group>"; };
 		CCD0ECC52B0DF016004FDED3 /* Hand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hand.swift; sourceTree = "<group>"; };
 		CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPPlayable.swift; sourceTree = "<group>"; };
+		CCD0ECC92B0E0E61004FDED3 /* RSPResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPResult.swift; sourceTree = "<group>"; };
+		CCD0ECCB2B0E0F0B004FDED3 /* Judge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Judge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +71,8 @@
 				C7ABA0E0254EA63000B2367D /* main.swift */,
 				CCD0ECC52B0DF016004FDED3 /* Hand.swift */,
 				CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */,
+				CCD0ECC92B0E0E61004FDED3 /* RSPResult.swift */,
+				CCD0ECCB2B0E0F0B004FDED3 /* Judge.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -132,6 +138,8 @@
 				CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */,
 				CCD0ECC62B0DF016004FDED3 /* Hand.swift in Sources */,
 				CCD0ECC82B0E0AEB004FDED3 /* RSPPlayable.swift in Sources */,
+				CCD0ECCA2B0E0E61004FDED3 /* RSPResult.swift in Sources */,
+				CCD0ECCC2B0E0F0B004FDED3 /* Judge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
+		CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,6 +26,7 @@
 /* Begin PBXFileReference section */
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +59,7 @@
 		C7ABA0DF254EA63000B2367D /* RockPaperScissors */ = {
 			isa = PBXGroup;
 			children = (
+				CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */,
 				C7ABA0E0254EA63000B2367D /* main.swift */,
 			);
 			path = RockPaperScissors;
@@ -120,6 +123,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
+				CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		CCD0ECC82B0E0AEB004FDED3 /* RSPPlayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */; };
 		CCD0ECCA2B0E0E61004FDED3 /* RSPResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC92B0E0E61004FDED3 /* RSPResult.swift */; };
 		CCD0ECCC2B0E0F0B004FDED3 /* Judge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECCB2B0E0F0B004FDED3 /* Judge.swift */; };
+		CCD0ECCE2B0E1DD8004FDED3 /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECCD2B0E1DD8004FDED3 /* Menu.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -35,6 +36,7 @@
 		CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPPlayable.swift; sourceTree = "<group>"; };
 		CCD0ECC92B0E0E61004FDED3 /* RSPResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPResult.swift; sourceTree = "<group>"; };
 		CCD0ECCB2B0E0F0B004FDED3 /* Judge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Judge.swift; sourceTree = "<group>"; };
+		CCD0ECCD2B0E1DD8004FDED3 /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +75,7 @@
 				CCD0ECC72B0E0AEB004FDED3 /* RSPPlayable.swift */,
 				CCD0ECC92B0E0E61004FDED3 /* RSPResult.swift */,
 				CCD0ECCB2B0E0F0B004FDED3 /* Judge.swift */,
+				CCD0ECCD2B0E1DD8004FDED3 /* Menu.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -136,6 +139,7 @@
 			files = (
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
 				CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */,
+				CCD0ECCE2B0E1DD8004FDED3 /* Menu.swift in Sources */,
 				CCD0ECC62B0DF016004FDED3 /* Hand.swift in Sources */,
 				CCD0ECC82B0E0AEB004FDED3 /* RSPPlayable.swift in Sources */,
 				CCD0ECCA2B0E0E61004FDED3 /* RSPResult.swift in Sources */,

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
 		CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */; };
+		CCD0ECC62B0DF016004FDED3 /* Hand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD0ECC52B0DF016004FDED3 /* Hand.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,6 +28,7 @@
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSPApp.swift; sourceTree = "<group>"; };
+		CCD0ECC52B0DF016004FDED3 /* Hand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hand.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,6 +63,7 @@
 			children = (
 				CCD0ECC32B0DE7A0004FDED3 /* RSPApp.swift */,
 				C7ABA0E0254EA63000B2367D /* main.swift */,
+				CCD0ECC52B0DF016004FDED3 /* Hand.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -124,6 +127,7 @@
 			files = (
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
 				CCD0ECC42B0DE7A0004FDED3 /* RSPApp.swift in Sources */,
+				CCD0ECC62B0DF016004FDED3 /* Hand.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RockPaperScissors/RockPaperScissors/Hand.swift
+++ b/RockPaperScissors/RockPaperScissors/Hand.swift
@@ -1,0 +1,25 @@
+//
+//  Hand.swift
+//  RockPaperScissors
+//
+//  Created by Roh on 11/22/23.
+//
+
+import Foundation
+
+enum Hand: Int, CaseIterable {
+    case rock = 2
+    case scissor = 1
+    case paper = 3
+    
+    func wins(_ another: Hand) -> Bool {
+        switch self {
+        case .rock:
+            return another == .scissor
+        case .scissor:
+            return another == .paper
+        case .paper:
+            return another == .rock
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Judge.swift
+++ b/RockPaperScissors/RockPaperScissors/Judge.swift
@@ -1,0 +1,21 @@
+//
+//  Judge.swift
+//  RockPaperScissors
+//
+//  Created by Roh on 11/22/23.
+//
+
+import Foundation
+
+final class Judge {
+    func judgeIf(_ leftPlayer: RSPPlayable, wins rightPlayer: RSPPlayable) -> RSPResult {
+        let lhs: Hand = leftPlayer.hand
+        let rhs: Hand = rightPlayer.hand
+        if lhs == rhs {
+            return .tie
+        } else {
+            let winner = lhs.wins(rhs) ? leftPlayer : rightPlayer
+            return .winning(winner)
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/Judge.swift
+++ b/RockPaperScissors/RockPaperScissors/Judge.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class Judge {
-    func judgeIf(_ leftPlayer: RSPPlayable, wins rightPlayer: RSPPlayable) -> RSPResult {
+    func judgeBetween(_ leftPlayer: RSPPlayable, _ rightPlayer: RSPPlayable) -> RSPResult {
         let lhs: Hand = leftPlayer.hand
         let rhs: Hand = rightPlayer.hand
         if lhs == rhs {

--- a/RockPaperScissors/RockPaperScissors/Menu.swift
+++ b/RockPaperScissors/RockPaperScissors/Menu.swift
@@ -1,0 +1,23 @@
+//
+//  Menu.swift
+//  RockPaperScissors
+//
+//  Created by Roh on 11/22/23.
+//
+
+import Foundation
+
+enum Menu {
+    case rsp(userHand: Hand)
+    case exit
+    
+    init?(input: Int) {
+        if let hand = Hand(rawValue: input) {
+            self = .rsp(userHand: hand)
+        } else if input == 0 {
+            self = .exit
+        } else {
+            return nil
+        }
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -1,0 +1,41 @@
+//
+//  RSPApp.swift
+//  RockPaperScissors
+//
+//  Created by Roh on 11/22/23.
+//
+
+import Foundation
+
+final class RSPApp {
+    private var isRunning: Bool = true
+    
+    func run() {
+        while isRunning {
+            // 프롬포터 출력
+            printPrompt()
+            // 입력 받기
+            guard let input = getInput() else {
+                print("잘못된 입력입니다. 다시 시도해주세요.")
+                continue
+            }
+            print("입력: ", input)
+            // 입력 > 가위바위보로 바꾸기
+            
+            
+                // 성공 -> process
+                // 실패 -> "잘못된 입력입니다. 다시 시도해주세요." 출력
+        }
+    }
+    
+    private func printPrompt() {
+        print("가위(1), 바위(2), 보(3)! <종료 : 0> :", terminator: " ")
+    }
+    
+    private func getInput() -> String? {
+        guard let pureInput = Swift.readLine() else { return nil }
+        // 문자열 가공
+        let result = pureInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return result.isEmpty ? nil : result
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -61,7 +61,7 @@ extension RSPApp {
     }
     
     private func judgeIfUserWins(winner: RSPPlayable) {
-        if let winner = winner as? UserPlayer, winner === userPlayer {
+        if let winner = winner as? UserPlayer, winner === self.userPlayer {
             printMessage(.winning)
         } else {
             printMessage(.losing)
@@ -91,7 +91,6 @@ extension RSPApp {
     }
     
     private func printMessage(_ message: Message, terminator: String? = nil) {
-        print(message, terminator: terminator ?? "\n")
+        Swift.print(message.rawValue, terminator: terminator ?? "\n")
     }
 }
- 

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -21,8 +21,12 @@ final class RSPApp {
             }
             print("입력: ", input)
             // 입력 > 가위바위보로 바꾸기
-            
-            
+            guard let intInput = Int(input) else {
+                print("잘못된 입력입니다. 다시 시도해주세요.")
+                continue
+            }
+            let rohHand = Hand.init(rawValue: intInput)
+            print(rohHand)
                 // 성공 -> process
                 // 실패 -> "잘못된 입력입니다. 다시 시도해주세요." 출력
         }

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -46,7 +46,7 @@ extension RSPApp {
         guard let userPlayer, let pcPlayer else {
             return
         }
-        let result = self.judge.judgeIf(userPlayer, wins: pcPlayer)
+        let result = self.judge.judgeBetween(userPlayer, pcPlayer)
         handleResult(result)
     }
     

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -10,8 +10,6 @@ import Foundation
 final class RSPApp {
     private var isRunning: Bool = true
     
-    private let invalidErrorMessage: String = "잘못된 입력입니다. 다시 시도해주세요."
-    
     let judge: Judge = Judge()
     
     var userPlayer: UserPlayer?
@@ -20,11 +18,11 @@ final class RSPApp {
     
     func run() {
         while self.isRunning {
-            printPrompt()
+            printMessage(.menuPrompt, terminator: " ")
             guard let input = getInput(),
                   let intInput = Int(input),
-                  let menu = Menu(input: intInput) else { #warning("상수")
-                printInvalidErrorMessage()
+                  let menu = Menu(input: intInput) else {
+                printMessage(.invalidError)
                 continue
             }
             processMenu(menu)
@@ -55,7 +53,7 @@ extension RSPApp {
     private func handleResult(_ result: RSPResult) {
         switch result {
         case .tie:
-            print("비겼습니다!")
+            printMessage(.tie)
         case .winning(let player):
             judgeIfUserWins(winner: player)
             exit()
@@ -64,31 +62,36 @@ extension RSPApp {
     
     private func judgeIfUserWins(winner: RSPPlayable) {
         if let winner = winner as? UserPlayer, winner === userPlayer {
-            print("이겼습니다!")
+            printMessage(.winning)
         } else {
-            print("졌습니다!")
+            printMessage(.losing)
         }
     }
     
     private func exit() {
-        print("게임 종료")
+        printMessage(.exit)
         self.isRunning = false
     }
 }
 
 extension RSPApp {
+    private enum Message: String {
+        case menuPrompt = "가위(1), 바위(2), 보(3)! <종료 : 0> :"
+        case invalidError = "잘못된 입력입니다. 다시 시도해주세요."
+        case winning = "이겼습니다!"
+        case losing = "졌습니다!"
+        case tie = "비겼습니다!"
+        case exit = "게임 종료"
+    }
+    
     private func getInput() -> String? {
         guard let pureInput = Swift.readLine() else { return nil }
         let result = pureInput.trimmingCharacters(in: .whitespacesAndNewlines)
         return result.isEmpty ? nil : result
     }
     
-    private func printInvalidErrorMessage() {
-        print(self.invalidErrorMessage)
-    }
-    
-    private func printPrompt() {
-        print("가위(1), 바위(2), 보(3)! <종료 : 0> :", terminator: " ")
+    private func printMessage(_ message: Message, terminator: String? = nil) {
+        print(message, terminator: terminator ?? "\n")
     }
 }
  

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -10,26 +10,34 @@ import Foundation
 final class RSPApp {
     private var isRunning: Bool = true
     
+    private let invalidErrorMessage: String = "잘못된 입력입니다. 다시 시도해주세요."
+    
+    private func printInvalidErrorMessage() {
+        print(invalidErrorMessage)
+    }
+    
     func run() {
         while isRunning {
             // 프롬포터 출력
             printPrompt()
             // 입력 받기
             guard let input = getInput() else {
-                print("잘못된 입력입니다. 다시 시도해주세요.")
+                printInvalidErrorMessage()
                 continue
             }
-            print("입력: ", input)
             // 입력 > 가위바위보로 바꾸기
             guard let intInput = Int(input) else {
-                print("잘못된 입력입니다. 다시 시도해주세요.")
+                printInvalidErrorMessage()
                 continue
             }
             let rohHand = Hand.init(rawValue: intInput)
-            print(rohHand)
                 // 성공 -> process
                 // 실패 -> "잘못된 입력입니다. 다시 시도해주세요." 출력
         }
+    }
+    
+    private func errorMessage() {
+        
     }
     
     private func printPrompt() {

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -18,10 +18,6 @@ final class RSPApp {
     
     var pcPlayer: PCPlayer?
     
-    private func printInvalidErrorMessage() {
-        print(invalidErrorMessage)
-    }
-    
     func run() {
         while isRunning {
             printPrompt()
@@ -34,23 +30,9 @@ final class RSPApp {
             processMenu(menu)
         }
     }
-    
-    private func printPrompt() {
-        print("가위(1), 바위(2), 보(3)! <종료 : 0> :", terminator: " ")
-    }
-    
-    private func getInput() -> String? {
-        guard let pureInput = Swift.readLine() else { return nil }
-        // 문자열 가공
-        let result = pureInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        return result.isEmpty ? nil : result
-    }
-    
-    private func exit() {
-        print("게임 종료")
-        self.isRunning = false
-    }
-    
+}
+
+extension RSPApp {
     private func processMenu(_ menu: Menu) {
         switch menu {
         case .rsp(let userHand):
@@ -79,4 +61,26 @@ final class RSPApp {
             exit()
         }
     }
+    
+    private func exit() {
+        print("게임 종료")
+        self.isRunning = false
+    }
 }
+
+extension RSPApp {
+    private func getInput() -> String? {
+        guard let pureInput = Swift.readLine() else { return nil }
+        let result = pureInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        return result.isEmpty ? nil : result
+    }
+    
+    private func printInvalidErrorMessage() {
+        print(invalidErrorMessage)
+    }
+    
+    private func printPrompt() {
+        print("가위(1), 바위(2), 보(3)! <종료 : 0> :", terminator: " ")
+    }
+}
+ 

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -19,7 +19,7 @@ final class RSPApp {
     var pcPlayer: PCPlayer?
     
     func run() {
-        while isRunning {
+        while self.isRunning {
             printPrompt()
             guard let input = getInput(),
                   let intInput = Int(input),
@@ -36,29 +36,37 @@ extension RSPApp {
     private func processMenu(_ menu: Menu) {
         switch menu {
         case .rsp(let userHand):
-            self.userPlayer = UserPlayer(hand: userHand)
-            self.pcPlayer = PCPlayer()
-            guard let userPlayer, let pcPlayer else {
-                return
-            }
-            let result = judge.judgeIf(userPlayer, wins: pcPlayer)
-            handleResult(result)
+            playOneRound(with: userHand)
         case .exit:
             exit()
         }
+    }
+    
+    private func playOneRound(with userHand: Hand) {
+        self.userPlayer = UserPlayer(hand: userHand)
+        self.pcPlayer = PCPlayer()
+        guard let userPlayer, let pcPlayer else {
+            return
+        }
+        let result = self.judge.judgeIf(userPlayer, wins: pcPlayer)
+        handleResult(result)
     }
     
     private func handleResult(_ result: RSPResult) {
         switch result {
         case .tie:
             print("비겼습니다!")
-        case .winning(let winner):
-            if let winner = winner as? UserPlayer, winner === userPlayer {
-                print("이겼습니다!")
-            } else {
-                print("졌습니다!")
-            }
+        case .winning(let player):
+            judgeIfUserWins(winner: player)
             exit()
+        }
+    }
+    
+    private func judgeIfUserWins(winner: RSPPlayable) {
+        if let winner = winner as? UserPlayer, winner === userPlayer {
+            print("이겼습니다!")
+        } else {
+            print("졌습니다!")
         }
     }
     
@@ -76,7 +84,7 @@ extension RSPApp {
     }
     
     private func printInvalidErrorMessage() {
-        print(invalidErrorMessage)
+        print(self.invalidErrorMessage)
     }
     
     private func printPrompt() {

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -10,11 +10,11 @@ import Foundation
 final class RSPApp {
     private var isRunning: Bool = true
     
-    let judge: Judge = Judge()
+    private let judge: Judge = Judge()
     
-    var userPlayer: UserPlayer?
+    private var userPlayer: UserPlayer?
     
-    var pcPlayer: PCPlayer?
+    private var pcPlayer: PCPlayer?
     
     func run() {
         while self.isRunning {

--- a/RockPaperScissors/RockPaperScissors/RSPApp.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPApp.swift
@@ -12,32 +12,27 @@ final class RSPApp {
     
     private let invalidErrorMessage: String = "잘못된 입력입니다. 다시 시도해주세요."
     
+    let judge: Judge = Judge()
+    
+    var userPlayer: UserPlayer?
+    
+    var pcPlayer: PCPlayer?
+    
     private func printInvalidErrorMessage() {
         print(invalidErrorMessage)
     }
     
     func run() {
         while isRunning {
-            // 프롬포터 출력
             printPrompt()
-            // 입력 받기
-            guard let input = getInput() else {
+            guard let input = getInput(),
+                  let intInput = Int(input),
+                  let menu = Menu(input: intInput) else { #warning("상수")
                 printInvalidErrorMessage()
                 continue
             }
-            // 입력 > 가위바위보로 바꾸기
-            guard let intInput = Int(input) else {
-                printInvalidErrorMessage()
-                continue
-            }
-            let rohHand = Hand.init(rawValue: intInput)
-                // 성공 -> process
-                // 실패 -> "잘못된 입력입니다. 다시 시도해주세요." 출력
+            processMenu(menu)
         }
-    }
-    
-    private func errorMessage() {
-        
     }
     
     private func printPrompt() {
@@ -49,5 +44,39 @@ final class RSPApp {
         // 문자열 가공
         let result = pureInput.trimmingCharacters(in: .whitespacesAndNewlines)
         return result.isEmpty ? nil : result
+    }
+    
+    private func exit() {
+        print("게임 종료")
+        self.isRunning = false
+    }
+    
+    private func processMenu(_ menu: Menu) {
+        switch menu {
+        case .rsp(let userHand):
+            self.userPlayer = UserPlayer(hand: userHand)
+            self.pcPlayer = PCPlayer()
+            guard let userPlayer, let pcPlayer else {
+                return
+            }
+            let result = judge.judgeIf(userPlayer, wins: pcPlayer)
+            handleResult(result)
+        case .exit:
+            exit()
+        }
+    }
+    
+    private func handleResult(_ result: RSPResult) {
+        switch result {
+        case .tie:
+            print("비겼습니다!")
+        case .winning(let winner):
+            if let winner = winner as? UserPlayer, winner === userPlayer {
+                print("이겼습니다!")
+            } else {
+                print("졌습니다!")
+            }
+            exit()
+        }
     }
 }

--- a/RockPaperScissors/RockPaperScissors/RSPPlayable.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPPlayable.swift
@@ -1,0 +1,32 @@
+//
+//  RSPPlayable.swift
+//  RockPaperScissors
+//
+//  Created by Roh on 11/22/23.
+//
+
+import Foundation
+
+protocol RSPPlayable {
+    var hand: Hand { get set }
+}
+
+final class UserPlayer: RSPPlayable {
+    var hand: Hand
+    
+    init(hand: Hand) {
+        self.hand = hand
+    }
+}
+
+final class PCPlayer: RSPPlayable {
+    var hand: Hand
+    
+    init() {
+        self.hand = PCPlayer.randomizeHand()
+    }
+    
+    private static func randomizeHand() -> Hand {
+        Hand.allCases.randomElement() ?? .rock
+    }
+}

--- a/RockPaperScissors/RockPaperScissors/RSPResult.swift
+++ b/RockPaperScissors/RockPaperScissors/RSPResult.swift
@@ -1,0 +1,13 @@
+//
+//  RSPResult.swift
+//  RockPaperScissors
+//
+//  Created by Roh on 11/22/23.
+//
+
+import Foundation
+
+enum RSPResult {
+    case winning(RSPPlayable)
+    case tie
+}

--- a/RockPaperScissors/RockPaperScissors/main.swift
+++ b/RockPaperScissors/RockPaperScissors/main.swift
@@ -2,9 +2,9 @@
 //  RockPaperScissors - main.swift
 //  Created by tacocat.
 //  Copyright © tastycode. All rights reserved.
-// 
+//
 
 import Foundation
 
-print("Hello, World!")
-
+let rspApp = RSPApp()
+rspApp.run()


### PR DESCRIPTION
@minsson 안녕하세요. 노움 에피입니다! 첫 리뷰 잘 부탁드려요.

저희는 이번 스텝에서 각 객체의 역할을 명확히 구분하고, 코드의 가독성을 높일 수 있는 방향으로 [⛺️코딩 컨벤션](https://github.com/rohhyungwoo/ios-rock-scissor-paper/wiki/%E2%9B%BA%EF%B8%8F-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EB%A3%B0)을 지키는 걸 중점으로 작업을 진행했는데요.

객체의 역할과, 객체 간의 소통을 중점적으로 리뷰해주시면 정말 많은 도움이 될 것 같습니다.

## 설계 설명

### RSPApp

- **Menu**는 사용자 입력에 따라 게임 진행 / 게임 종료를 표현하는 열거형입니다.
- **App**은 루프를 돌며 사용자 입력에 따라 게임을 진행하고, 게임 결과를 출력합니다.

### RSPPlayable

- **Hand**는 플레이어가 내는 가위 / 바위 / 보를 표현하는 열거형입니다.
- **Playable**을 채택한 타입은 **Hand**를 속성으로 가져야 합니다.
- **UserPlayer, PCPlayer**는 **RSPPlayable**을 채택하고,
- **PCPlayer**는 생성 시점에 랜덤한 **Hand**를 초기화합니다.
- **UserPlayer**는 전달된 **Hand**로 초기화됩니다.

### Judge

- 두 플레이어 중 승자를 가려 결과를 리턴하는 역할의 객체입니다.
- `judgeIf` 메소드는 무승부 또는 누군가 이긴 상황을 표현하는 **RSPResult** 타입을 리턴합니다.

## 질문

### Optional인 Player의 값을 어떻게 보장해야 할까

원래는 RSPPlayer의 hand를 Hand?로 선언해서, 기본적으로 App의 userPlayer와 pcPlayer는 초기화 되어 있고, 사용자 입력이 들어오면 플레이어의 hand에 값을 설정하도록 구현했었는데요. 심판을 하기 전에 플레이어의 hand에 값이 있는지 확인하는 로직이 필요한데, 이 로직이 누락될 가능성이 있다는 생각이 들었습니다.

그래서 기존 hand의 타입을 non-optional Hand로 교체하고, hand를 전달해 플레이어를 생성하도록 구현을 수정했습니다.

```swift
protocol RSPPlayable {
    var hand: Hand { get set }
}

final class UserPlayer: RSPPlayable {
    var hand: Hand
    
    init(hand: Hand) {
        self.hand = hand
    }
}

final class PCPlayer: RSPPlayable {
    var hand: Hand
    
    init() {
        self.hand = PCPlayer.randomizeHand()
    }
    
    private static func randomizeHand() -> Hand {
        Hand.allCases.randomElement() ?? .rock
    }
}
```

하지만 여전히 App의 레벨에서는 다음처럼 userPlayer와 pcPlayer가 존재하는지 확인하는 로직이 필요한 상태입니다.

```swift
private func playOneRound(with userHand: Hand) {
        self.userPlayer = UserPlayer(hand: userHand)
        self.pcPlayer = PCPlayer()
        guard let userPlayer, let pcPlayer else {
            return
        }
        let result = self.judge.judgeIf(userPlayer, wins: pcPlayer)
        handleResult(result)
    }
```

혹시 현재의 구현보다 더 나은 구현 방법이 있는지 궁금합니다!

### 가위바위보 로직과 로직의 위치

현재 가위 바위 보에서 승자를 판단하는 로직은 두 단계로 이루어져 있습니다.

1. 두 개의 Hand, 즉 가위, 바위, 보 사이에서 한 Hand가 이겼는지 아닌지를 판단하는 로직
    
    ```swift
    enum Hand: Int, CaseIterable {
        case rock = 2
        case scissor = 1
        case paper = 3
        
        func wins(_ another: Hand) -> Bool {
            switch self {
            case .rock:
                return another == .scissor
            case .scissor:
                return another == .paper
            case .paper:
                return another == .rock
            }
        }
    }
    ```
    
2. 임의의 두 플레이어가 비겼는지, 또는 누군가가 이겼는지를 판단하는 로직
    
    ```swift
    final class Judge {
        func judgeIf(_ leftPlayer: RSPPlayable, wins rightPlayer: RSPPlayable) -> RSPResult {
            let lhs: Hand = leftPlayer.hand
            let rhs: Hand = rightPlayer.hand
            if lhs == rhs {
                return .tie
            } else {
                let winner = lhs.wins(rhs) ? leftPlayer : rightPlayer
                return .winning(winner)
            }
        }
    }
    ```
    

두 단계를 나누고, 로직의 위치를 고민하다가 1번 단계는 Hand 의 기능으로, 2번은 Judge의 기능으로 분리했는데요. 각 객체들에게 각각의 역할이 어울린다고 생각하시는지 민쏜의 의견이 궁금합니다~

### 심판 로직과 사용자 승리를 판단하는 로직

RSPApp의 `judgeIfUserWins` 메소드에서 심판으로부터 받아온 가위바위보 결과(RSPResult)의 승자가 App이 가지고 있는 userPlayer와 같은지 확인하는 로직을 다음처럼 구현했는데요.

```swift
private func judgeIfUserWins(winner: RSPPlayable) {
        if let winner = winner as? UserPlayer, winner === userPlayer {
            printMessage(.winning)
        } else {
            printMessage(.losing)
        }
    }
```

결과의 승자(RSPPlayable)을 UserPlayer로 캐스팅하고, 이 유저와 App의 현재 유저의 동일성을 비교하는 로직인데요. 현재 user가 옵셔널인데다가, 변수로 선언되어 있어서 지금과 같은 로직으로 구현된 것 같은데, 이런 방식이 적절한지, 더 좋은 방식이 있는지 민쏜의 의견이 궁금합니다.