### PR TITLE
묵찌빠 프로그램 [STEP 2] Tommy

### DIFF
--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		95BC5B7C2B0DBDB900EBCB35 /* RockPaperScissorsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BC5B7B2B0DBDB900EBCB35 /* RockPaperScissorsManager.swift */; };
 		95BC5B7E2B14A48E00EBCB35 /* ResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BC5B7D2B14A48E00EBCB35 /* ResultType.swift */; };
+		95D1D9902B16C4800064ADD1 /* MukchippaResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D1D98F2B16C4800064ADD1 /* MukchippaResult.swift */; };
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
 		D0AF43D12B0C3EF400A21FF8 /* GameResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0AF43D02B0C3EF400A21FF8 /* GameResult.swift */; };
 /* End PBXBuildFile section */
@@ -28,6 +29,7 @@
 /* Begin PBXFileReference section */
 		95BC5B7B2B0DBDB900EBCB35 /* RockPaperScissorsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsManager.swift; sourceTree = "<group>"; };
 		95BC5B7D2B14A48E00EBCB35 /* ResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultType.swift; sourceTree = "<group>"; };
+		95D1D98F2B16C4800064ADD1 /* MukchippaResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukchippaResult.swift; sourceTree = "<group>"; };
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D0AF43D02B0C3EF400A21FF8 /* GameResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResult.swift; sourceTree = "<group>"; };
@@ -48,6 +50,7 @@
 			isa = PBXGroup;
 			children = (
 				D0AF43D02B0C3EF400A21FF8 /* GameResult.swift */,
+				95D1D98F2B16C4800064ADD1 /* MukchippaResult.swift */,
 				95BC5B7D2B14A48E00EBCB35 /* ResultType.swift */,
 			);
 			path = Enum;
@@ -136,6 +139,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95D1D9902B16C4800064ADD1 /* MukchippaResult.swift in Sources */,
 				95BC5B7E2B14A48E00EBCB35 /* ResultType.swift in Sources */,
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
 				D0AF43D12B0C3EF400A21FF8 /* GameResult.swift in Sources */,

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		95BC5B7C2B0DBDB900EBCB35 /* RockPaperScissorsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BC5B7B2B0DBDB900EBCB35 /* RockPaperScissorsManager.swift */; };
-		95BC5B7E2B14A48E00EBCB35 /* ResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BC5B7D2B14A48E00EBCB35 /* ResultType.swift */; };
+		95BC5B7E2B14A48E00EBCB35 /* RockPaperScissorsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BC5B7D2B14A48E00EBCB35 /* RockPaperScissorsResult.swift */; };
 		95D1D9902B16C4800064ADD1 /* MukchippaResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D1D98F2B16C4800064ADD1 /* MukchippaResult.swift */; };
 		C7ABA0E1254EA63000B2367D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ABA0E0254EA63000B2367D /* main.swift */; };
 		D0AF43D12B0C3EF400A21FF8 /* GameResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0AF43D02B0C3EF400A21FF8 /* GameResult.swift */; };
@@ -28,7 +28,7 @@
 
 /* Begin PBXFileReference section */
 		95BC5B7B2B0DBDB900EBCB35 /* RockPaperScissorsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsManager.swift; sourceTree = "<group>"; };
-		95BC5B7D2B14A48E00EBCB35 /* ResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultType.swift; sourceTree = "<group>"; };
+		95BC5B7D2B14A48E00EBCB35 /* RockPaperScissorsResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsResult.swift; sourceTree = "<group>"; };
 		95D1D98F2B16C4800064ADD1 /* MukchippaResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MukchippaResult.swift; sourceTree = "<group>"; };
 		C7ABA0DD254EA63000B2367D /* RockPaperScissors */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = RockPaperScissors; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7ABA0E0254EA63000B2367D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -51,7 +51,7 @@
 			children = (
 				D0AF43D02B0C3EF400A21FF8 /* GameResult.swift */,
 				95D1D98F2B16C4800064ADD1 /* MukchippaResult.swift */,
-				95BC5B7D2B14A48E00EBCB35 /* ResultType.swift */,
+				95BC5B7D2B14A48E00EBCB35 /* RockPaperScissorsResult.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -140,7 +140,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				95D1D9902B16C4800064ADD1 /* MukchippaResult.swift in Sources */,
-				95BC5B7E2B14A48E00EBCB35 /* ResultType.swift in Sources */,
+				95BC5B7E2B14A48E00EBCB35 /* RockPaperScissorsResult.swift in Sources */,
 				C7ABA0E1254EA63000B2367D /* main.swift in Sources */,
 				D0AF43D12B0C3EF400A21FF8 /* GameResult.swift in Sources */,
 				95BC5B7C2B0DBDB900EBCB35 /* RockPaperScissorsManager.swift in Sources */,

--- a/RockPaperScissors/RockPaperScissors/Enum/MukchippaResult.swift
+++ b/RockPaperScissors/RockPaperScissors/Enum/MukchippaResult.swift
@@ -12,15 +12,36 @@ enum MukchippaResult: Int {
     case computer = 1
     case user = 2
 
-    var turnMessage: String {
-        return self == .user ? "[사용자 턴]" : "[컴퓨터 턴]"
+    var turnMessage: String? {
+        switch self {
+        case .user:
+            return "[사용자 턴]"
+        case .computer:
+            return "[컴퓨터 턴]"
+        case .draw:
+            return nil
+        }
     }
 
-    var winMessage: String {
-        return self == .user ? "사용자의 승리" : "컴퓨터의 승리"
+    var winMessage: String? {
+            switch self {
+            case .user:
+                return "사용자의 승리"
+            case .computer:
+                return "컴퓨터의 승리"
+            case .draw:
+                return nil
+            }
     }
 
-    var turnStartMessage: String {
-        return self == .computer ? "컴퓨터의 턴입니다." : "사용자의 턴입니다"
+    var turnStartMessage: String? {
+        switch self {
+        case .user:
+            return "사용자의 턴입니다"
+        case .computer:
+            return "컴퓨터의 턴입니다"
+        case .draw:
+            return nil
+        }
     }
 }

--- a/RockPaperScissors/RockPaperScissors/Enum/MukchippaResult.swift
+++ b/RockPaperScissors/RockPaperScissors/Enum/MukchippaResult.swift
@@ -1,0 +1,14 @@
+//
+//  MukchippaResult.swift
+//  RockPaperScissors
+//
+//  Created by nayeon  on 2023/11/29.
+//
+
+import Foundation
+
+enum MukchippaResult: Int {
+    case draw = 0
+    case computerWin = 1
+    case computerLose = 2
+}

--- a/RockPaperScissors/RockPaperScissors/Enum/MukchippaResult.swift
+++ b/RockPaperScissors/RockPaperScissors/Enum/MukchippaResult.swift
@@ -11,4 +11,16 @@ enum MukchippaResult: Int {
     case draw = 0
     case computer = 1
     case user = 2
+
+    var turnMessage: String {
+        return self == .user ? "[사용자 턴]" : "[컴퓨터 턴]"
+    }
+
+    var winMessage: String {
+        return self == .user ? "사용자의 승리" : "컴퓨터의 승리"
+    }
+
+    var turnStartMessage: String {
+        return self == .computer ? "컴퓨터의 턴입니다." : "사용자의 턴입니다"
+    }
 }

--- a/RockPaperScissors/RockPaperScissors/Enum/MukchippaResult.swift
+++ b/RockPaperScissors/RockPaperScissors/Enum/MukchippaResult.swift
@@ -9,6 +9,6 @@ import Foundation
 
 enum MukchippaResult: Int {
     case draw = 0
-    case computerWin = 1
-    case computerLose = 2
+    case computer = 1
+    case user = 2
 }

--- a/RockPaperScissors/RockPaperScissors/Enum/RockPaperScissorsResult.swift
+++ b/RockPaperScissors/RockPaperScissors/Enum/RockPaperScissorsResult.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ResultType: Int {
+enum RockPaperScissorsResult: Int {
     case draw = 0
     case userWin = 1
     case userLose = 2

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -12,10 +12,13 @@ struct RockPaperScissorsManager {
     private var randomValue: Int?
     private var resultValue: Int?
     private var status: Bool = true
+    private var currentTurn: MukchippaResult = .draw
+    private var nextRound: Bool = false
+    private var lastTurn: MukchippaResult = .draw
     
     mutating func play() {
         while status {
-            print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
+            RoundCheck()
             
             guard let input = readLine() else { return }
             userValue = Int(input)
@@ -31,6 +34,14 @@ struct RockPaperScissorsManager {
             default:
                 print(GameResult.wrongValue.rawValue)
             }
+        }
+    }
+    
+    mutating func RoundCheck() {
+        if !nextRound {
+            print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
+        } else {
+            print(currentTurn == MukchippaResult.computerLose ? "[사용자 턴] " : "[컴퓨터 턴] ", "묵(1),찌(2),빠(3)! <종료 : 0> : " , terminator: "")
         }
     }
 

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -13,11 +13,11 @@ struct RockPaperScissorsManager {
     private var resultValue: Int?
     private var status: Bool = true
     private var currentTurn: MukchippaResult = .draw
-    private var nextRound: Bool = false
+    private var isNextRound: Bool = false
     
     mutating func play() {
         while status {
-            stepCheck()
+            checkStepPrint()
             guard let input = readLine() else { return }
             userValue = Int(input)
             
@@ -27,23 +27,23 @@ struct RockPaperScissorsManager {
                 status = false
             case 1, 2, 3:
                 guard let userChoice = userValue else { return }
-                stepType(userChoice: userChoice)
+                checkStepType(userChoice: userChoice)
             default:
                 print(GameResult.wrongValue.rawValue)
             }
         }
     }
     
-    mutating func stepCheck() {
-        if !nextRound {
+    mutating func checkStepPrint() {
+        if !isNextRound {
             print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
         } else {
             print(currentTurn == MukchippaResult.computerLose ? "[사용자 턴] " : "[컴퓨터 턴] ", "묵(1),찌(2),빠(3)! <종료 : 0> : " , terminator: "")
         }
     }
     
-    mutating func stepType(userChoice: Int) {
-        if !nextRound {
+    mutating func checkStepType(userChoice: Int) {
+        if !isNextRound {
             getRockPaperScissorsResult(userValue: userChoice)
         } else {
             getMukchippaResult(userValue: userChoice)
@@ -66,11 +66,11 @@ struct RockPaperScissorsManager {
         case .userWin:
             print(GameResult.win.rawValue)
             currentTurn = .computerLose
-            nextRound = true
+            isNextRound = true
         case .userLose:
             currentTurn = .computerWin
             print(GameResult.lose.rawValue)
-            nextRound = true
+            isNextRound = true
         case .none:
             break
         }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -18,7 +18,7 @@ struct RockPaperScissorsManager {
     
     mutating func play() {
         while status {
-            RoundCheck()
+            stepCheck()
             guard let input = readLine() else { return }
             userValue = Int(input)
             
@@ -28,22 +28,26 @@ struct RockPaperScissorsManager {
                 status = false
             case 1, 2, 3:
                 guard let userChoice = userValue else { return }
-                if !nextRound {
-                    getRockPaperScissorsResult(userValue: userChoice)
-                } else {
-                    getMukchippaResult(userValue: userChoice)
-                }
+                stepType(userChoice: userChoice)
             default:
                 print(GameResult.wrongValue.rawValue)
             }
         }
     }
     
-    mutating func RoundCheck() {
+    mutating func stepCheck() {
         if !nextRound {
             print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
         } else {
             print(currentTurn == MukchippaResult.computerLose ? "[사용자 턴] " : "[컴퓨터 턴] ", "묵(1),찌(2),빠(3)! <종료 : 0> : " , terminator: "")
+        }
+    }
+    
+    mutating func stepType(userChoice: Int) {
+        if !nextRound {
+            getRockPaperScissorsResult(userValue: userChoice)
+        } else {
+            getMukchippaResult(userValue: userChoice)
         }
     }
     

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -19,7 +19,6 @@ struct RockPaperScissorsManager {
     mutating func play() {
         while status {
             RoundCheck()
-            
             guard let input = readLine() else { return }
             userValue = Int(input)
             
@@ -30,7 +29,7 @@ struct RockPaperScissorsManager {
             case 1, 2, 3:
                 guard let userChoice = userValue else { return }
                 if !nextRound {
-                    getResult(userValue: userChoice)
+                    getRockPaperScissorsResult(userValue: userChoice)
                 } else {
                     getMukchippaResult(userValue: userChoice)
                 }
@@ -52,14 +51,13 @@ struct RockPaperScissorsManager {
         randomValue = Int.random(in: 1...3)
         guard let computerValue = randomValue else { return }
         resultValue = (userValue - computerValue + 3) % 3
-        print("computer의 값 : ",randomValue) // 코드 테스트 - 삭제
     }
 
-    mutating func getResult(userValue: Int) {
+    mutating func getRockPaperScissorsResult(userValue: Int) {
         calculateValue(userValue: userValue)
         guard let gameValue = resultValue else { return }
         
-        switch ResultType(rawValue: gameValue) {
+        switch RockPaperScissorsResult(rawValue: gameValue) {
         case .draw:
             print(GameResult.draw.rawValue)
         case .userWin:

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -13,7 +13,7 @@ struct RockPaperScissorsManager {
     private var status: Bool = true
     private var currentTurn: MukchippaResult = .draw
     private var isNextRound: Bool = false
-    
+
     mutating func play() {
         while status {
             checkStepPrint()
@@ -33,7 +33,7 @@ struct RockPaperScissorsManager {
         }
     }
     
-    mutating func checkStepPrint() {
+    private mutating func checkStepPrint() {
         if !isNextRound {
             print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
         } else {
@@ -43,7 +43,7 @@ struct RockPaperScissorsManager {
         }
     }
     
-    mutating func checkStepType(userChoice: Int) {
+    private mutating func checkStepType(userChoice: Int) {
         if !isNextRound {
             getRockPaperScissorsResult(userValue: userChoice)
         } else {
@@ -51,12 +51,12 @@ struct RockPaperScissorsManager {
         }
     }
     
-    mutating func calculateValue(userValue: Int) -> Int {
+    private mutating func calculateValue(userValue: Int) -> Int {
         let randomValue = Int.random(in: 1...3)
         return (userValue - randomValue + 3) % 3
     }
 
-    mutating func getRockPaperScissorsResult(userValue: Int) {
+    private mutating func getRockPaperScissorsResult(userValue: Int) {
         let gameValue = calculateValue(userValue: userValue)
         
         switch RockPaperScissorsResult(rawValue: gameValue) {
@@ -75,7 +75,7 @@ struct RockPaperScissorsManager {
         }
     }
     
-    mutating func getMukchippaResult(userValue: Int) {
+    private mutating func getMukchippaResult(userValue: Int) {
         let gameValue = calculateValue(userValue: userValue)
             
         switch MukchippaResult(rawValue: gameValue) {

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -14,7 +14,6 @@ struct RockPaperScissorsManager {
     private var status: Bool = true
     private var currentTurn: MukchippaResult = .draw
     private var nextRound: Bool = false
-    private var lastTurn: MukchippaResult = .draw
     
     mutating func play() {
         while status {
@@ -83,15 +82,13 @@ struct RockPaperScissorsManager {
             
         switch MukchippaResult(rawValue: gameValue) {
         case .computerWin:
-            lastTurn = .computerWin
             currentTurn = .computerWin
             print("컴퓨터의 턴입니다.")
         case .computerLose:
-            lastTurn = .computerLose
             currentTurn = .computerLose
             print("사용자의 턴입니다")
         case .draw:
-            print(lastTurn == .computerLose ? "사용자의 승리" : "컴퓨터의 승리")
+            print(currentTurn == .computerLose ? "사용자의 승리" : "컴퓨터의 승리")
             status = false
         case .none:
             break

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -9,7 +9,6 @@ import Foundation
 
 struct RockPaperScissorsManager {
     private var userValue: Int?
-    private var randomValue: Int?
     private var resultValue: Int?
     private var status: Bool = true
     private var currentTurn: MukchippaResult = .draw
@@ -50,15 +49,13 @@ struct RockPaperScissorsManager {
         }
     }
     
-    mutating func calculateValue(userValue: Int) {
-        randomValue = Int.random(in: 1...3)
-        guard let computerValue = randomValue else { return }
-        resultValue = (userValue - computerValue + 3) % 3
+    mutating func calculateValue(userValue: Int) -> Int {
+        let randomValue = Int.random(in: 1...3)
+        return (userValue - randomValue + 3) % 3
     }
 
     mutating func getRockPaperScissorsResult(userValue: Int) {
-        calculateValue(userValue: userValue)
-        guard let gameValue = resultValue else { return }
+        let gameValue = calculateValue(userValue: userValue)
         
         switch RockPaperScissorsResult(rawValue: gameValue) {
         case .draw:
@@ -77,8 +74,7 @@ struct RockPaperScissorsManager {
     }
     
     mutating func getMukchippaResult(userValue: Int) {
-        calculateValue(userValue: userValue)
-        guard let gameValue = resultValue else { return }
+        let gameValue = calculateValue(userValue: userValue)
             
         switch MukchippaResult(rawValue: gameValue) {
         case .computerWin:

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -28,8 +28,11 @@ struct RockPaperScissorsManager {
                 print(GameResult.exit.rawValue)
                 status = false
             case 1, 2, 3:
-                if let userChoice = userValue {
+                guard let userChoice = userValue else { return }
+                if !nextRound {
                     getResult(userValue: userChoice)
+                } else {
+                    getMukchippaResult(userValue: userChoice)
                 }
             default:
                 print(GameResult.wrongValue.rawValue)

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -37,7 +37,7 @@ struct RockPaperScissorsManager {
         if !isNextRound {
             print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
         } else {
-            let turnMessage = currentTurn == MukchippaResult.computerLose ? "[사용자 턴]" : "[컴퓨터 턴]"
+            let turnMessage = currentTurn == MukchippaResult.user ? "[사용자 턴]" : "[컴퓨터 턴]"
             let mukchippaMessage = "묵(1),찌(2),빠(3)! <종료 : 0> : "
             print(turnMessage, mukchippaMessage , terminator: "")
         }
@@ -64,10 +64,10 @@ struct RockPaperScissorsManager {
             print(GameResult.draw.rawValue)
         case .userWin:
             print(GameResult.win.rawValue)
-            currentTurn = .computerLose
+            currentTurn = .user
             isNextRound = true
         case .userLose:
-            currentTurn = .computerWin
+            currentTurn = .computer
             print(GameResult.lose.rawValue)
             isNextRound = true
         case .none:
@@ -79,14 +79,14 @@ struct RockPaperScissorsManager {
         let gameValue = calculateValue(userValue: userValue)
             
         switch MukchippaResult(rawValue: gameValue) {
-        case .computerWin:
-            currentTurn = .computerWin
+        case .computer:
+            currentTurn = .computer
             print("컴퓨터의 턴입니다.")
-        case .computerLose:
-            currentTurn = .computerLose
+        case .user:
+            currentTurn = .user
             print("사용자의 턴입니다")
         case .draw:
-            print(currentTurn == .computerLose ? "사용자의 승리" : "컴퓨터의 승리")
+            print(currentTurn == .user ? "사용자의 승리" : "컴퓨터의 승리")
             status = false
         case .none:
             break

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -44,12 +44,16 @@ struct RockPaperScissorsManager {
             print(currentTurn == MukchippaResult.computerLose ? "[사용자 턴] " : "[컴퓨터 턴] ", "묵(1),찌(2),빠(3)! <종료 : 0> : " , terminator: "")
         }
     }
-
-    mutating func getResult(userValue: Int) {
+    
+    mutating func calculateValue(userValue: Int) {
         randomValue = Int.random(in: 1...3)
-        
         guard let computerValue = randomValue else { return }
         resultValue = (userValue - computerValue + 3) % 3
+        print("computer의 값 : ",randomValue) // 코드 테스트 - 삭제
+    }
+
+    mutating func getResult(userValue: Int) {
+        calculateValue(userValue: userValue)
         guard let gameValue = resultValue else { return }
         
         switch ResultType(rawValue: gameValue) {

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -64,8 +64,10 @@ struct RockPaperScissorsManager {
             print(GameResult.draw.rawValue)
         case .userWin:
             print(GameResult.win.rawValue)
+            currentTurn = .computerLose
             nextRound = true
         case .userLose:
+            currentTurn = .computerWin
             print(GameResult.lose.rawValue)
             nextRound = true
         case .none:

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -69,4 +69,25 @@ struct RockPaperScissorsManager {
             break
         }
     }
+    
+    mutating func getMukchippaResult(userValue: Int) {
+        calculateValue(userValue: userValue)
+        guard let gameValue = resultValue else { return }
+            
+        switch MukchippaResult(rawValue: gameValue) {
+        case .computerWin:
+            lastTurn = .computerWin
+            currentTurn = .computerWin
+            print("컴퓨터의 턴입니다.")
+        case .computerLose:
+            lastTurn = .computerLose
+            currentTurn = .computerLose
+            print("사용자의 턴입니다")
+        case .draw:
+            print(lastTurn == .computerLose ? "사용자의 승리" : "컴퓨터의 승리")
+            status = false
+        case .none:
+            break
+        }
+    }
 }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -37,7 +37,7 @@ struct RockPaperScissorsManager {
         if !isNextRound {
             print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
         } else {
-            let turnMessage = currentTurn == MukchippaResult.user ? "[사용자 턴]" : "[컴퓨터 턴]"
+            let turnMessage = currentTurn.turnMessage
             let mukchippaMessage = "묵(1),찌(2),빠(3)! <종료 : 0> : "
             print(turnMessage, mukchippaMessage , terminator: "")
         }
@@ -81,12 +81,12 @@ struct RockPaperScissorsManager {
         switch MukchippaResult(rawValue: gameValue) {
         case .computer:
             currentTurn = .computer
-            print("컴퓨터의 턴입니다.")
+            print(currentTurn.turnStartMessage)
         case .user:
             currentTurn = .user
-            print("사용자의 턴입니다")
+            print(currentTurn.turnStartMessage)
         case .draw:
-            print(currentTurn == .user ? "사용자의 승리" : "컴퓨터의 승리")
+            print(currentTurn.winMessage)
             status = false
         case .none:
             break

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -16,7 +16,7 @@ struct RockPaperScissorsManager {
 
     mutating func play() {
         while status {
-            checkStepPrint()
+            printStep()
             guard let input = readLine() else { return }
             userValue = Int(input)
             
@@ -33,7 +33,7 @@ struct RockPaperScissorsManager {
         }
     }
     
-    private mutating func checkStepPrint() {
+    private mutating func printStep() {
         if !isNextRound {
             print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
         } else {

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -37,7 +37,7 @@ struct RockPaperScissorsManager {
         if !isNextRound {
             print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
         } else {
-            let turnMessage = currentTurn.turnMessage
+            guard let turnMessage = currentTurn.turnMessage else { return }
             let mukchippaMessage = "묵(1),찌(2),빠(3)! <종료 : 0> : "
             print(turnMessage, mukchippaMessage , terminator: "")
         }
@@ -81,12 +81,18 @@ struct RockPaperScissorsManager {
         switch MukchippaResult(rawValue: gameValue) {
         case .computer:
             currentTurn = .computer
-            print(currentTurn.turnStartMessage)
+            if let message = currentTurn.turnStartMessage {
+                print(message)
+            }
         case .user:
             currentTurn = .user
-            print(currentTurn.turnStartMessage)
+            if let message = currentTurn.turnStartMessage {
+                print(message)
+            }
         case .draw:
-            print(currentTurn.winMessage)
+            if let message = currentTurn.winMessage {
+                print(message)
+            }
             status = false
         case .none:
             break

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -57,10 +57,10 @@ struct RockPaperScissorsManager {
             print(GameResult.draw.rawValue)
         case .userWin:
             print(GameResult.win.rawValue)
-            status = false
+            nextRound = true
         case .userLose:
             print(GameResult.lose.rawValue)
-            status = false
+            nextRound = true
         case .none:
             break
         }

--- a/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
+++ b/RockPaperScissors/RockPaperScissors/RockPaperScissorsManager.swift
@@ -37,7 +37,9 @@ struct RockPaperScissorsManager {
         if !isNextRound {
             print("가위(1), 바위(2), 보(3)! <종료: 0> : ", terminator: "")
         } else {
-            print(currentTurn == MukchippaResult.computerLose ? "[사용자 턴] " : "[컴퓨터 턴] ", "묵(1),찌(2),빠(3)! <종료 : 0> : " , terminator: "")
+            let turnMessage = currentTurn == MukchippaResult.computerLose ? "[사용자 턴]" : "[컴퓨터 턴]"
+            let mukchippaMessage = "묵(1),찌(2),빠(3)! <종료 : 0> : "
+            print(turnMessage, mukchippaMessage , terminator: "")
         }
     }
     


### PR DESCRIPTION
> 리뷰어 : @ICS-Asan
> 
> 
> 버드 : @angryeon7
> 

안녕하세요. 아샌-!

step2 피드백 잘부탁드립니다!

## 구현 기능

### STEP2

- 코드 중복 최소화를 위해 메서드 분리를 통해 묵찌빠 게임에 사용
- `stepCheck()` `stepType()`
    - `nextRound` 값에 따라 해당 라운드를 출력 / 진행
- 게임의 승패 상태를 저장
    - 열거형 타입에서 메시지를 분리하여 명시성 추가
- `getRockPaperScissorsResult` : 메시지 출력 후 `nextRound` 값을 변경하여 다음 라운드로 진행
     - 묵찌빠 게임이 추가됨에 따라 함수 및 변수명을 묵찌빠와 맞춰 변경하였습니다.
- `getMukchippaResult` : 묵찌빠 게임에 따라 사용자의 승패 판정 결과를 출력
    - 비기는 경우, 해당 턴인 사람을 승자로 게임을 종료
    - 나머지의 경우, 해당 턴인 사람을 저장하고 출력후 계속 게임을 진행함



---

## 고민했던 부분

- 함수를 기능 단위로 분리해 작성해봤습니다. 더 분리해야할 부분이 있는지 아니면 과도하게 분리한 부분이 있는지 궁금합니다.
- `가위(1) 바위(2) 보(3)` 와 `묵(1) 찌(2) 빠(3)` 에서 1,2 가 의미하는 바가 달라서 열거형을 하나 더 생성하였는데 묵찌빠에서 사용하는 타입으로 변환하는 함수를 생성하는 방법도 생각해 보았는데 어떤 부분이 더 효율적이라고 생각하시나요?
- 함수명이 너무 긴것같다는 생각이 드는데 어떻게 생각하시나요?
- RockPaperScissorsManager가 너무 무거운게 아닌지 생각이 듭니다. 묵찌빠와 가위바위보를 나누는 걸로 설계를 했어야했을까요..?